### PR TITLE
Fixes split_integrated_address()

### DIFF
--- a/Monero_Payments.php
+++ b/Monero_Payments.php
@@ -105,7 +105,7 @@
      }
      
     public function split_integrated_address($integrated_address){
-        if(isset($integrated_address)){
+        if(!isset($integrated_address)){
             echo "Error: Integrated_Address mustn't be null";
         }
         else{


### PR DESCRIPTION
Changed if(isset($integrated_address)) to  if(!isset($integrated_address)) so that it functions properly.