### PR TITLE
Fixes typo in incoming_transfers function so that it functions properly

### DIFF
--- a/Monero_Payments.php
+++ b/Monero_Payments.php
@@ -75,10 +75,10 @@
      * Incoming Transfer
      * $type must be All 
      */
-   public function incoming_transfer($type){
+   public function incoming_transfers($type){
         $incoming_parameters = array('transfer_type' => $type);
-        $incoming_transfer = $this->_run('incoming_transfer', $incoming_parameters);
-        $this->_print($incoming_transfer);
+        $incoming_transfers = $this->_run('incoming_transfers', $incoming_parameters);
+        $this->_print($incoming_transfers);
     }
   
     public function get_transfers(){


### PR DESCRIPTION
Changes get_transfer() to get_transfers() and adds the 's' to $query_key_method = $this->_run('query_key', $query_key); so that it works properly with the rpc wallet.