### PR TITLE
Change default monero-wallet-rpc port to 18083/28083/38083

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ monerod --testnet --detach
 
 2. Start the Monero wallet RPC interface (`monero-wallet-rpc`) on testnet
 ```bash
-monero-wallet-rpc --testnet --rpc-bind-port 28082 --disable-rpc-login --wallet-dir /path/to/wallet/directory
+monero-wallet-rpc --testnet --rpc-bind-port 28083 --disable-rpc-login --wallet-dir /path/to/wallet/directory
 ```
 
-3. Edit `example.php` with your the IP address of `monerod` and `monero-wallet-rpc` (use `127.0.0.1:28081` and `127.0.0.1:28082`, respectively, for testnet)
+3. Edit `example.php` with your the IP address of `monerod` and `monero-wallet-rpc` (use `127.0.0.1:28081` and `127.0.0.1:28083`, respectively, for testnet)
 
 4. Open your browser with your IP address of local webserver (*eg.* XMPP, Apache/Apache2, NGINX, *etc.*) and execute example.php.  If everything has been set up correctly, information from your Monero daemon and wallet will be displayed.

--- a/example.php
+++ b/example.php
@@ -26,8 +26,8 @@ $get_info = $daemonRPC->get_info();
 
 require_once('src/walletRPC.php');
 
-$walletRPC = new walletRPC('127.0.0.1', 28082); // Change to match your wallet (monero-wallet-rpc) IP address and port; 18082 is the default port for mainnet, 28082 for testnet, 38082 for stagenet
-// $create_wallet = $walletRPC->create_wallet('monero_wallet', ''); // Creates a new wallet named monero_wallet with no passphrase.  Comment this line and edit the next line to use your own wallet
+$walletRPC = new walletRPC('127.0.0.1', 28083); // Change to match your wallet (monero-wallet-rpc) IP address and port; 18083 is the customary port for mainnet, 28083 for testnet, 38083 for stagenet
+$create_wallet = $walletRPC->create_wallet('monero_wallet', ''); // Creates a new wallet named monero_wallet with no passphrase.  Comment this line and edit the next line to use your own wallet
 $open_wallet = $walletRPC->open_wallet('monero_wallet', '');
 $get_address = $walletRPC->get_address();
 $get_accounts = $walletRPC->get_accounts();

--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -51,7 +51,7 @@ class walletRPC
    * @param  string  $password  Password                                       (optional)
    *
    */
-  function __construct ($host = '127.0.0.1', $port = '18080', $protocol = 'http', $user = null, $password = null)
+  function __construct ($host = '127.0.0.1', $port = 18083, $protocol = 'http', $user = null, $password = null)
   {
     // TODO input validation
     


### PR DESCRIPTION
ZeroMQ binds to port 18082, 28082, or 38082, so the docs and defaults should change to reflect that.  User s1ph3r in #monero-dev threw a fit over "two hours wasted" with that issue, heh, so let's update, shall we?