### PR TITLE
Fix get_payments, get_bulk_payments, and transfer

### DIFF
--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -819,7 +819,9 @@ class walletRPC
    */
   public function get_payments($payment_id)
   {
-    $get_payments_parameters = array('payment_id' => $payment_id);
+    // $get_payments_parameters = array('payment_id' => $payment_id); // does not work
+    $get_payments_parameters = [];
+    $get_payments_parameters['payment_id'] = $payment_id;
     return $this->_run('get_payments', $get_payments_parameters);
   }
   
@@ -843,7 +845,18 @@ class walletRPC
    */
   public function get_bulk_payments($payment_ids, $min_block_height)
   {
-    $get_bulk_payments_parameters = array('payment_ids' => $payment_ids, 'min_block_height' => $min_block_height);
+    // $get_bulk_payments_parameters = array('payment_ids' => $payment_ids, 'min_block_height' => $min_block_height); // does not work
+    $get_bulk_payments_parameters = array('min_block_height' => $min_block_height); // does not work
+    $get_bulk_payments_parameters = [];
+    if (!is_array($payment_ids)) {
+      throw new Exception('Error: Payment IDs must be array.');
+    }
+    if ($payment_ids) {
+      $get_bulk_payments_parameters['payment_ids'] = [];
+      foreach ($payment_ids as $payment_id) {
+        array_push($get_bulk_payments_parameters['payment_ids'], $payment_id);
+      }
+    }
     return $this->_run('get_bulk_payments', $get_bulk_payments_parameters);
   }
   

--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -483,7 +483,7 @@ class walletRPC
         } else {
           throw new Exception('Error: Address required');
         }
-        $destinations = array(array('amount' => $new_amount, 'address' => $address));
+        $destinations = array(array('amount' => $this->_transform($amount), 'address' => $address));
       }
       if (array_key_exists('payment_id', $params)) {
         $payment_id = $params['payment_id'];


### PR DESCRIPTION
Deepest apologies, in testing this this morning there is a single $new_amount that I've left behind in `transfer` as of #54 ... I will in the future make a more comprehensive unit testing suite to stop myself committing these mistakes in the future.

In addition, I have just added a fix for the issue discussed at/around https://mattermost.getmonero.org/monero/pl/3onjcmhoypnodkfgm8dk9i4nse where PHP was not properly casting payment IDs as string.  `get_payments` and `get_bulk_payments` now work as expected.