### PR TITLE
Add get_client alias, document getClient & get_client & document aliases

### DIFF
--- a/docs/walletRPC.md
+++ b/docs/walletRPC.md
@@ -15,8 +15,8 @@ Parameters:
 ### Methods
 
  - [`_transform`](#_transform)
- - [`get_balance`](#get_balance)
- - [`get_address`](#get_address)
+ - [`get_balance` (alias: `getbalance`)](#get_balance)
+ - [`get_address` (alias: `getaddress`)](#get_address)
  - [`create_address`](#create_address)
  - [`label_address`](#label_address)
  - [`get_accounts`](#get_accounts)
@@ -26,7 +26,7 @@ Parameters:
  - [`tag_accounts`](#tag_accounts)
  - [`untag_accounts`](#untag_accounts)
  - [`set_account_tag_description`](#set_account_tag_description)
- - [`get_height`](#get_height)
+ - [`get_height` (alias: `getheight`)](#get_height)
  - [`transfer`](#transfer)
  - [`transfer_split`](#transfer_split)
  - [`sweep_dust`](#sweep_dust)
@@ -83,6 +83,7 @@ Parameters:
  - [`finalize_multisig`](#finalize_multisig)
  - [`sign_multisig`](#sign_multisig)
  - [`submit_multisig`](#submit_multisig)
+ - [`get_client` (alias: `getClient`)](#get_client)
 
 #### `_transform`
 
@@ -1113,6 +1114,14 @@ Parameters:
 Return: `<Object>`
 
 [//]: # (TODO example)
+
+#### `get_client`
+
+Return the `jsonRPCClient` used by the class
+
+Return: `jsonRPCClient`
+
+Alias: `getClient`
 
 ### Credits
 

--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -1748,11 +1748,19 @@ class walletRPC
     return $this->_run('submit_multisig', $params);
   }
 
-    /**
-     * @return jsonRPCClient
-     */
-    public function getClient()
-    {
-        return $this->client;
-    }
+  /**
+   * @return jsonRPCClient
+   */
+  public function get_client()
+  {
+      return $this->client;
+  }
+
+  /**
+   * @return jsonRPCClient
+   */
+  public function getClient()
+  {
+      return $this->client;
+  }
 }


### PR DESCRIPTION
`getClient` and `get_client` are now aliases of eachother.  They are now documented in `docs/walletRPC.md`.  And the `getaddress`, `getbalance`, and `getheight` aliases are also documented now.