### PR TITLE
Allow daemon and wallet RPC classes to be optionally constructed with parameters passed in as objects/dictionaries (associative arrays)

### DIFF
--- a/docs/daemonRPC.md
+++ b/docs/daemonRPC.md
@@ -6,12 +6,19 @@ A class for making calls to a Monero daemon's RPC API using PHP
 
 Parameters:
 
- - `$protocol <String>` Monero daemon IP hostname *(optional)*
  - `$host <String>` Monero daemon port *(optional)*
  - `$port <nNmber>` Monero daemon protocol (*eg.* 'http') *(optional)*
- - `$url <String>` Monero daemon RPC username *(optional)*
- - `$user <String>` Monero daemon RPC passphrase *(optional)*
+ - `$protocol <String>` Monero daemon IP hostname *(optional)*
+ - `$user <String>` Monero daemon RPC username *(optional)*
  - `$password <String>` Monero daemon RPC passphrase *(optional)*
+
+Parameters can also be passed in as an associative array (object/dictionary,) as in:
+
+```php
+$daemonRPC = new daemonRPC(['host' => '127.0.0.1', 'port' => 28081])
+```
+
+If an object is used to provide parameters (as above,) parameters can be declared in any order.
 
 ### Methods
 

--- a/docs/walletRPC.md
+++ b/docs/walletRPC.md
@@ -12,6 +12,14 @@ Parameters:
  - `$user <String>` monero-wallet-rpc RPC username *(optional)*
  - `$password <String>` monero-wallet-rpc RPC passphrase *(optional)*
 
+Parameters can also be passed in as an associative array (object/dictionary,) as in:
+
+```php
+$walletRPC = new walletRPC(['host' => '127.0.0.1', 'port' => 28083])
+```
+
+If an object is used to provide parameters (as above,) parameters can be declared in any order.
+
 ### Methods
 
  - [`_transform`](#_transform)

--- a/example.php
+++ b/example.php
@@ -9,6 +9,7 @@ require_once('src/jsonRPCClient.php');
 require_once('src/daemonRPC.php');
 
 $daemonRPC = new daemonRPC('127.0.0.1', 28081); // Change to match your daemon (monerod) IP address and port; 18081 is the default port for mainnet, 28081 for testnet, 38081 for stagenet
+// $daemonRPC = new daemonRPC(['host' => '127.0.0.1', 'port' => 28081]) // Passing parameters in as array; parameters can be in any order and all are optional.
 $getblockcount = $daemonRPC->getblockcount();
 $on_getblockhash = $daemonRPC->on_getblockhash(42069);
 // $getblocktemplate = $daemonRPC->getblocktemplate('9sZABNdyWspcpsCPma1eUD5yM3efTHfsiCx3qB8RDYH9UFST4aj34s5Ygz69zxh8vEBCCqgxEZxBAEC4pyGkN4JEPmUWrxn', 60);
@@ -27,6 +28,7 @@ $get_info = $daemonRPC->get_info();
 require_once('src/walletRPC.php');
 
 $walletRPC = new walletRPC('127.0.0.1', 28083); // Change to match your wallet (monero-wallet-rpc) IP address and port; 18083 is the customary port for mainnet, 28083 for testnet, 38083 for stagenet
+// $daemonRPC = new walletRPC(['host' => '127.0.0.1', 'port' => 28081]) // Passing parameters in as array; parameters can be in any order and all are optional.
 $create_wallet = $walletRPC->create_wallet('monero_wallet', ''); // Creates a new wallet named monero_wallet with no passphrase.  Comment this line and edit the next line to use your own wallet
 $open_wallet = $walletRPC->open_wallet('monero_wallet', '');
 $get_address = $walletRPC->get_address();

--- a/src/daemonRPC.php
+++ b/src/daemonRPC.php
@@ -56,6 +56,28 @@ class daemonRPC
    */
   function __construct($host = '127.0.0.1', $port = 18081, $protocol = 'http', $user = null, $password = null)
   {
+    if (is_array($host)) { // Parameters passed in as object/dictionary
+      $params = $host;
+
+      if (array_key_exists('host', $params)) {
+        $host = $params['host'];
+      } else {
+        $host = '127.0.0.1';
+      }
+      if (array_key_exists('port', $params)) {
+        $port = $params['port'];
+      }
+      if (array_key_exists('protocol', $params)) {
+        $protocol = $params['protocol'];
+      }
+      if (array_key_exists('user', $params)) {
+        $user = $params['user'];
+      }
+      if (array_key_exists('password', $params)) {
+        $password = $params['password'];
+      }
+    }
+    
     $this->host = $host;
     $this->port = $port;
     $this->protocol = $protocol;

--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -55,6 +55,28 @@ class walletRPC
    */
   function __construct ($host = '127.0.0.1', $port = 18083, $protocol = 'http', $user = null, $password = null)
   {
+    if (is_array($host)) { // Parameters passed in as object/dictionary
+      $params = $host;
+
+      if (array_key_exists('host', $params)) {
+        $host = $params['host'];
+      } else {
+        $host = '127.0.0.1';
+      }
+      if (array_key_exists('port', $params)) {
+        $port = $params['port'];
+      }
+      if (array_key_exists('protocol', $params)) {
+        $protocol = $params['protocol'];
+      }
+      if (array_key_exists('user', $params)) {
+        $user = $params['user'];
+      }
+      if (array_key_exists('password', $params)) {
+        $password = $params['password'];
+      }
+    }
+    
     $this->host = $host;
     $this->port = $port;
     $this->protocol = $protocol;


### PR DESCRIPTION
This pull request adds the *optional* (backwards-compatible) ability for the wallet and daemon RPC classes to be initialized with/parameters passed in as objects/dictionaries (associative arrays.)  After this pull request, RPC classes can be initialized in any of the following ways:

```php
$daemonRPC = new daemonRPC('127.0.0.1', 28082);
```

```php
$daemonRPC = new daemonRPC(['host' => '127.0.0.1', 'port' => 28082]);
```

*or*

```php
$daemonRPC = new daemonRPC(['user' => 'username', 'password' => 'passphrase']);
```

The last example demonstrates how parameters can be passed in in any order or combination, with parameters using their default values if they're not defined.

This pull request isn't necessary at the moment but it does add the capability needed to pass in `['autoconnect' => true]`, which is the next functionality I'm adding (see https://github.com/sneurlax/moneronodejs/commit/9f17be53cf43e9e1136536d5527b738af330a3e5 for the autoconnect functionality I'm going to port over here.)

This is optional and backwards-compatible, *ie.* nobody has to change what they're doing now; all current code will continue working as normal.