### PR TITLE
temporary check_spend_proof fix

### DIFF
--- a/src/jsonRPCClient.php
+++ b/src/jsonRPCClient.php
@@ -112,10 +112,12 @@ class jsonRPCClient
                 'Request: ' . $request . '; ';
             if (isset($responseDecoded['error']['data']))
             {
-                /* check_spend_proof fix in case of checking a different txid than one used to sign the signature */
-                if( $responseDecoded['error']['message'] == 'incorrect signature size' ) {
-                    $fakeReturn = array( 'result' => array( 'good' => false ) );
-                    return $fakeReturn['result'];
+                /* check_spend_proof fix in case of different txid than one used to sign the signature */
+                if( $pMethod === 'check_spend_proof' ) {                
+                    if( $responseDecoded['error']['message'] === 'incorrect signature size' ) {
+                        $fakeReturn = array( 'result' => array( 'good' => false ) );
+                        return $fakeReturn['result'];
+                    }
                 }
                 
                 $errorMessage .= "\n" . 'Error data: ' . $responseDecoded['error']['data'];

--- a/src/jsonRPCClient.php
+++ b/src/jsonRPCClient.php
@@ -112,6 +112,12 @@ class jsonRPCClient
                 'Request: ' . $request . '; ';
             if (isset($responseDecoded['error']['data']))
             {
+                /* check_spend_proof fix in case of checking a different txid than one used to sign the signature */
+                if( $responseDecoded['error']['message'] == 'incorrect signature size' ) {
+                    $fakeReturn = array( 'result' => array( 'good' => false ) );
+                    return $fakeReturn['result'];
+                }
+                
                 $errorMessage .= "\n" . 'Error data: ' . $responseDecoded['error']['data'];
             }
             $this->validate( !is_null($responseDecoded['error']), $errorMessage);


### PR DESCRIPTION
```
$txid = 'd77b32a3dfb3a1f549100e4831f225f4b4be7ccb854982c14dd7048f624cb2f1';
$txid2 = '9c1e5ba94e50cd51d809ed013b6cc593a484b8991fcbaacf2edf4af69f6d3212';

$wat = $walletRPC->get_spend_proof( $txid );
echo 'get_spend_proof: ', PHP_EOL;
print_r( $wat );

$wat2 = $walletRPC->check_spend_proof( $txid2, $wat['signature'] );
echo 'check_spend_proof: ', PHP_EOL;
print_r( $wat2 );
```
This will return good=>false now, rather than throwing an exception because of 'incorrect signature size'