### PR TITLE
fix encode base58

### DIFF
--- a/src/base58.php
+++ b/src/base58.php
@@ -257,10 +257,7 @@ class base58
     $last_block_size = count($data) % self::$full_block_size;
     $res_size = $full_block_count * self::$full_encoded_block_size + self::$encoded_block_sizes[$last_block_size];
 
-    $res = array_fill(0, $res_size, 0);
-    for ($i = 0; $i < $res_size; $i++) {
-      $res[$i] = self::$alphabet[0];
-    }
+    $res = array_fill(0, $res_size, ord(self::$alphabet[0]));
 
     for ($i = 0; $i < $full_block_count; $i++) {
       $res = self::encode_block(array_slice($data, $i * self::$full_block_size, ($i * self::$full_block_size + self::$full_block_size) - ($i * self::$full_block_size)), $res, $i * self::$full_encoded_block_size);


### PR DESCRIPTION
fix losing symbols '1' when encode a hexadecimal string to Base58.

Hi, 

Methods _Cryptonote::integrated_addr_from_keys()_ , _base58::encode()_ return result without '1'

Code for get integrated address:
[gen_integaddr.txt](https://github.com/monero-integrations/monerophp/files/2233070/gen_integaddr.txt)

Results:
integrated address:
ref: 4DrvGduF3ynBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVPkNUtnN5hPM13TZaa4
gen: 4DrvGduF3ynBoZ4NMDwYtN8obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVPkNUtnN5hPM3TZaa4
