### PR TITLE
added needed extensions as requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=5.6.0",
+        "ext-bcmath": "*",
+        "ext-curl": "*",
+        "ext-json": "*"
+    },
+    "suggest": {
+        "ext-gmp": "Used to have a multiple math precision for generating address"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently when you install the package it will not throw exception if one of the fallowing extensions (see changes in composer.json) are missing.
I have changed that, it's like validation during package installation process.