### PR TITLE
$data_size == -1 check in base58 decode

### DIFF
--- a/src/base58.php
+++ b/src/base58.php
@@ -354,6 +354,10 @@ class base58
 
     $data_size = $full_block_count * self::$full_block_size + $last_block_decoded_size;
 
+    if ($data_size == -1) {
+      return '';
+    }
+
     $data = array_fill(0, $data_size, 0);
     for ($i = 0; $i <= $full_block_count; $i++) {
       $data = self::decode_block(array_slice($enc, $i * self::$full_encoded_block_size, ($i * self::$full_encoded_block_size + self::$full_encoded_block_size) - ($i * self::$full_encoded_block_size)), $data, $i * self::$full_block_size);


### PR DESCRIPTION
In function decode of class base58, if -1 is returned by index_of() this can lead to warnings:

PHP Warning:  array_fill(): Number of elements can't be negative

I sometimes run into this when using verify_checksum() on user input.
Added a simple check and return. 