### PR TITLE
Remove unnecessary Exception import in base58 code

### DIFF
--- a/src/base58.php
+++ b/src/base58.php
@@ -29,8 +29,6 @@
 
 namespace MoneroIntegrations\MoneroPhp;
 
-use Exception;
-
 class base58
 {
   static $alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';


### PR DESCRIPTION
Resolve PHP Warning: The use statement with non-compound name 'Exception' has no effect in \monerowp\include\class-monero-base58.php on line 29