### PR TITLE
corrected mnemonic namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,243 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/linux,macos,dotenv,laravel,windows,composer,intellij,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=linux,macos,dotenv,laravel,windows,composer,intellij,visualstudiocode
+
+### Composer ###
+composer.phar
+/vendor/
+
+# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+composer.lock
+
+### dotenv ###
+.env
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Laravel ###
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Laravel 4 specific
+bootstrap/compiled.php
+app/storage/
+
+# Laravel 5 & Lumen specific
+public/storage
+public/hot
+
+# Laravel 5 & Lumen specific with changed public path
+public_html/storage
+public_html/hot
+
+storage/*.key
+Homestead.yaml
+Homestead.json
+/.vagrant
+.phpunit.result.cache
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/linux,macos,dotenv,laravel,windows,composer,intellij,visualstudiocode
+
+/.php-version
+
+!.gitkeep

--- a/src/base58.php
+++ b/src/base58.php
@@ -41,12 +41,13 @@ class base58
    *
    * Convert a hexadecimal string to a binary array
    *
-   * @param    string  $hex  A hexadecimal string to convert to a binary array
+   * @param  string  $hex  A hexadecimal string to convert to a binary array
    *
    * @return   array
    *
+   * @throws Exception
    */
-  private function hex_to_bin($hex)
+  private function hex_to_bin($hex): array
   {
     if (!is_string($hex)) {
       throw new Exception('base58->hex_to_bin(): Invalid input type (must be a string)');
@@ -320,7 +321,7 @@ class base58
     if ($res_size < self::$full_block_size && bcpow(2, 8 * $res_size) <= 0) {
       throw new Exception('base58->decode_block(): Integer overflow (bcpow(2, 8 * $res_size) exceeds the maximum 64bit integer)');
     }
-  
+
     $tmp_buf = self::uint64_to_8_be($res_num, $res_size);
     for ($i = 0, $iMax = count($tmp_buf); $i < $iMax; $i++) {
       $buf[$i + $index] = $tmp_buf[$i];

--- a/src/mnemonic/chinese_simplified.php
+++ b/src/mnemonic/chinese_simplified.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class chinese_simplified implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,7 +14,7 @@ class chinese_simplified implements wordset {
         return "简体中文 (中国)";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -25,13 +27,13 @@ class chinese_simplified implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 1;  // first letter of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "的",

--- a/src/mnemonic/dutch.php
+++ b/src/mnemonic/dutch.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class dutch implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,7 +14,7 @@ class dutch implements wordset {
         return "Nederlands";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -25,13 +27,13 @@ class dutch implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "aalglad",
@@ -1659,7 +1661,7 @@ class dutch implements wordset {
             "zwepen",
             "zwiep",
             "zwijmel",
-            "zworen"            
+            "zworen"
         ];
     }
 }

--- a/src/mnemonic/english.php
+++ b/src/mnemonic/english.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class english implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,11 +14,11 @@ class english implements wordset {
         return "English";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
-        return "English";        
+        return "English";
     }
 
     /* Returns integer indicating length of unique prefix,
@@ -25,13 +27,13 @@ class english implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 3;  // first 3 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "abbey",

--- a/src/mnemonic/english_old.php
+++ b/src/mnemonic/english_old.php
@@ -7,6 +7,8 @@ namespace MoneroIntegrations\MoneroPhp\mnemonic;
  */
 
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class english_old implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -17,7 +19,7 @@ class english_old implements wordset {
         return "EnglishOld";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -30,13 +32,13 @@ class english_old implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 0;  // require entire word.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "like",

--- a/src/mnemonic/esperanto.php
+++ b/src/mnemonic/esperanto.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class esperanto implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,7 +14,7 @@ class esperanto implements wordset {
         return "Esperanto";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -25,13 +27,13 @@ class esperanto implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "abako",
@@ -1659,7 +1661,7 @@ class esperanto implements wordset {
             "zoologio",
             "zorgi",
             "zukino",
-            "zumilo",            
+            "zumilo",
         ];
     }
 }

--- a/src/mnemonic/french.php
+++ b/src/mnemonic/french.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class french implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -9,10 +11,10 @@ class french implements wordset {
      * if the language supports it.
      */
     static public function name() : string {
-        return "Français";        
+        return "Français";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -25,13 +27,13 @@ class french implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "abandon",

--- a/src/mnemonic/german.php
+++ b/src/mnemonic/german.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class german implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -9,10 +11,10 @@ class german implements wordset {
      * if the language supports it.
      */
     static public function name() : string {
-        return "Deutsch"; 
+        return "Deutsch";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -26,13 +28,13 @@ class german implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "Abakus",
@@ -1660,7 +1662,7 @@ class german implements wordset {
             "Zugvogel",
             "Zündung",
             "Zweck",
-            "Zyklop"            
+            "Zyklop"
         ];
     }
 }

--- a/src/mnemonic/italian.php
+++ b/src/mnemonic/italian.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class italian implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,7 +14,7 @@ class italian implements wordset {
         return "Italiano";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -25,13 +27,13 @@ class italian implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "abbinare",
@@ -1659,7 +1661,7 @@ class italian implements wordset {
             "zoccolo",
             "zolfo",
             "zombie",
-            "zucchero"            
+            "zucchero"
         ];
     }
 }

--- a/src/mnemonic/japanese.php
+++ b/src/mnemonic/japanese.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class japanese implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,7 +14,7 @@ class japanese implements wordset {
         return "日本語";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -25,13 +27,13 @@ class japanese implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 3;  // first 3 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "あいこくしん",
@@ -1659,7 +1661,7 @@ class japanese implements wordset {
             "ひさしぶり",
             "ひさん",
             "びじゅつかん",
-            "ひしょ"            
+            "ひしょ"
         ];
     }
 }

--- a/src/mnemonic/lojban.php
+++ b/src/mnemonic/lojban.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class lojban implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -9,14 +11,14 @@ class lojban implements wordset {
      * if the language supports it.
      */
     static public function name() : string {
-        return "Lojban";        
+        return "Lojban";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
-        return "Lojban";                
+        return "Lojban";
     }
 
     /* Returns integer indicating length of unique prefix,
@@ -25,13 +27,13 @@ class lojban implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "backi",

--- a/src/mnemonic/portuguese.php
+++ b/src/mnemonic/portuguese.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class portuguese implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -12,7 +14,7 @@ class portuguese implements wordset {
         return "Português";
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -26,13 +28,13 @@ class portuguese implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "abaular",

--- a/src/mnemonic/russian.php
+++ b/src/mnemonic/russian.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class russian implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -10,10 +12,10 @@ class russian implements wordset {
      */
     static public function name() : string {
         return "русский язык";
-        
+
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -26,13 +28,13 @@ class russian implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 3;  // first 3 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "абажур",
@@ -1660,7 +1662,7 @@ class russian implements wordset {
             "ясный",
             "яхта",
             "ячейка",
-            "ящик"            
+            "ящик"
        ];
     }
 }

--- a/src/mnemonic/spanish.php
+++ b/src/mnemonic/spanish.php
@@ -2,6 +2,8 @@
 
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+use MoneroIntegrations\MoneroPhp\wordset;
+
 class spanish implements wordset {
 
     /* Returns name of wordset in the wordset's native language.
@@ -10,10 +12,10 @@ class spanish implements wordset {
      */
     static public function name() : string {
         return "Español";
-        
+
     }
 
-    /* Returns name of wordset in english.    
+    /* Returns name of wordset in english.
      * This is a human-readable string, and should be capitalized
      */
     static public function english_name() : string {
@@ -27,13 +29,13 @@ class spanish implements wordset {
      *
      * A value of 0 indicates that there is no unique prefix
      * and the entire word must be used instead.
-     */    
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
-    
+
     /* Returns an array of all words in the wordset.
-     */    
+     */
     static public function words() : array {
         return [
             "ábaco",
@@ -1661,7 +1663,7 @@ class spanish implements wordset {
             "riqueza",
             "risa",
             "ritmo",
-            "rito"            
+            "rito"
         ];
     }
 }


### PR DESCRIPTION
this will get rid of all the psr-4 warnings.

```bash
Class MoneroIntegrations\MoneroPhp\mnemonic\dutch located in ./vendor/monero-integrations/monerophp/src/wordsets/dutch.ws.php does not comply with psr-4 autoloading standard. Skipping.
...
```

I suspect there is a reason, nobody as taken this task upon himself yet already?! (Just close this in that case, no worries ;) )