### PR TITLE
wip: Use PHPDoc for documentation

### DIFF
--- a/src/Varint.php
+++ b/src/Varint.php
@@ -22,8 +22,23 @@
 */
 namespace MoneroIntegrations\MoneroPhp;
 
-    class Varint
-    {
+
+/**
+ * Varint class
+ *
+ * Provides methods for encoding, decoding, and manipulating variable-length integers.
+ *
+ * @package MoneroIntegrations\MoneroPhp\Varint
+ */
+class Varint
+{
+        /**
+         * Encodes an integer as a varint.
+         *
+         * @param int $data The integer to be encoded.
+         * 
+         * @return string Hex-encoded representation of the varint.
+         */
         public function encode_varint($data)
         {
             $orig = $data;
@@ -45,7 +60,15 @@ namespace MoneroIntegrations\MoneroPhp;
             return bin2hex($bytes);
         }
         
-        // https://github.com/monero-project/research-lab/blob/master/source-code/StringCT-java/src/how/monero/hodl/util/VarInt.java
+        /**
+         * Decodes a varint into an integer.
+         * 
+         * Source: https://github.com/monero-project/research-lab/blob/master/source-code/StringCT-java/src/how/monero/hodl/util/VarInt.java
+         *
+         * @param string $data The hex-encoded varint.
+         * 
+         * @return int The decoded integer.
+         */
         public function decode_varint($data)
         {
             $result = 0;
@@ -71,6 +94,13 @@ namespace MoneroIntegrations\MoneroPhp;
             return $result;
         }
         
+        /**
+         * Pops the varint from the beginning of the data and returns the remaining data.
+         *
+         * @param string[] $data The hex-encoded data containing a varint.
+         * 
+         * @return string[] Hex-encoded data with the varint removed.
+         */
         public function pop_varint($data)
         {
             $result = 0;

--- a/src/base58.php
+++ b/src/base58.php
@@ -30,21 +30,54 @@
 namespace MoneroIntegrations\MoneroPhp;
 use Exception;
 
+/**
+ * Base58 Codec Class
+ *
+ * This class provides methods for encoding and decoding data using the base58 encoding scheme.
+ *
+ * @package MoneroIntegrations\MoneroPhp\base58
+ */
 class base58
 {
+  /**
+   * Base58 alphabet.
+   *
+   * @var string
+   * 
+   */
   static $alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+  /**
+   * Encoded block sizes for each block of bytes.
+   *
+   * @var array
+   * 
+   */
   static $encoded_block_sizes = [0, 2, 3, 5, 6, 7, 9, 10, 11];
+
+  /**
+   * Size of a block in bytes.
+   *
+   * @var int
+   * 
+   */
   static $full_block_size = 8;
+
+  /**
+   * Size of a fully-encoded block in bytes.
+   *
+   * @var int
+   * 
+   */
   static $full_encoded_block_size = 11;
 
   /**
+   * Convert a hexadecimal string to a binary array.
    *
-   * Convert a hexadecimal string to a binary array
-   *
-   * @param    string  $hex  A hexadecimal string to convert to a binary array
-   *
-   * @return   array
-   *
+   * @param string $hex A hexadecimal string to convert to a binary array.
+   * 
+   * @return array An array of binary values.
+   * 
    */
   private function hex_to_bin($hex)
   {
@@ -63,13 +96,12 @@ class base58
   }
 
   /**
+   * Convert a binary array to a hexadecimal string.
    *
-   * Convert a binary array to a hexadecimal string
-   *
-   * @param    array   $bin  A binary array to convert to a hexadecimal string
-   *
-   * @return   string
-   *
+   * @param array $bin A binary array to convert to a hexadecimal string.
+   * 
+   * @return string The resulting hexadecimal string.
+   * 
    */
   private function bin_to_hex($bin)
   {
@@ -85,13 +117,12 @@ class base58
   }
 
   /**
+   * Convert a string to a binary array.
    *
-   * Convert a string to a binary array
-   *
-   * @param    string   $str  A string to convert to a binary array
-   *
-   * @return   array
-   *
+   * @param string $str A string to convert to a binary array.
+   * 
+   * @return array An array of binary values.
+   * 
    */
   private function str_to_bin($str)
   {
@@ -107,13 +138,12 @@ class base58
   }
 
   /**
+   * Convert a binary array to a string.
    *
-   * Convert a binary array to a string
-   *
-   * @param    array   $bin  A binary array to convert to a string
-   *
-   * @return   string
-   *
+   * @param array $bin A binary array to convert to a string.
+   * 
+   * @return string The resulting string.
+   * 
    */
   private function bin_to_str($bin)
   {
@@ -129,13 +159,12 @@ class base58
   }
 
   /**
+   * Convert a UInt8BE (one unsigned big endian byte) array to UInt64.
    *
-   * Convert a UInt8BE (one unsigned big endian byte) array to UInt64
-   *
-   * @param    array   $data  A UInt8BE array to convert to UInt64
-   *
-   * @return   number
-   *
+   * @param array $data A UInt8BE array to convert to UInt64.
+   * 
+   * @return int The resulting UInt64 value.
+   * 
    */
   private function uint8_be_to_64($data)
   {
@@ -170,13 +199,12 @@ class base58
   }
 
   /**
+   * Convert a UInt64 (unsigned 64 bit integer) to a UInt8BE array.
    *
-   * Convert a UInt64 (unsigned 64 bit integer) to a UInt8BE array
+   * @param int $num A UInt64 number to convert to a UInt8BE array.
+   * @param int $size Size of array to return (1 <= $size <= 8).
    *
-   * @param    number   $num   A UInt64 number to convert to a UInt8BE array
-   * @param    integer  $size  Size of array to return
-   *
-   * @return   array
+   * @return int[] The UInt8BE array.
    *
    */
   private function uint64_to_8_be($num, $size)
@@ -200,14 +228,13 @@ class base58
   }
 
   /**
+   * Encode a hexadecimal array to a base58 string.
+   * 
+   * @param int[] $data The hexadecimal array to encode.
+   * @param int[] $buf The buffer to store the encoded data.
+   * @param int|float $index The starting index in the buffer.
    *
-   * Convert a hexadecimal (Base16) array to a Base58 string
-   *
-   * @param    array   $data
-   * @param    array   $buf
-   * @param    number  $index
-   *
-   * @return   array
+   * @return int[] The updated buffer after encoding.
    *
    */
   private function encode_block($data, $buf, $index)
@@ -237,13 +264,12 @@ class base58
   }
 
   /**
-   *
-   * Encode a hexadecimal (Base16) string to Base58
-   *
-   * @param    string  $hex  A hexadecimal (Base16) string to convert to Base58
-   *
-   * @return   string
-   *
+   * Encode a hexadecimal string to base58.
+   * 
+   * @param string $hex The hexadecimal string to encode.
+   * 
+   * @return string The base58 encoded string.
+   * 
    */
   public function encode($hex)
   {
@@ -274,14 +300,13 @@ class base58
   }
 
   /**
+   * Decode a base58 block to a hexadecimal array.
    *
-   * Convert a Base58 input to hexadecimal (Base16)
+   * @param int[] $data The base58 block to decode.
+   * @param int[] $buf The buffer to store the decoded data.
+   * @param int|float $index The starting index in the buffer.
    *
-   * @param    array    $data
-   * @param    array    $buf
-   * @param    integer  $index
-   *
-   * @return   array
+   * @return int[] The updated buffer after decoding.
    *
    */
   private function decode_block($data, $buf, $index)
@@ -329,12 +354,11 @@ class base58
   }
 
   /**
+   * Decode a base58 input to hexadecimal.
    *
-   * Decode a Base58 string to hexadecimal (Base16)
+   * @param string $enc The base58 string to decode.
    *
-   * @param    string  $hex  A Base58 string to convert to hexadecimal (Base16)
-   *
-   * @return   string
+   * @return string The decoded hexadecimal string.
    *
    */
   public function decode($enc)
@@ -370,14 +394,14 @@ class base58
   }
 
   /**
-   *
-   * Search an array for a value
+   * Search an array for a value.
+   * 
    * Source: https://stackoverflow.com/a/30994678
    *
-   * @param    array   $haystack  An array to search
-   * @param    string  $needle    A string to search for
-   *)
-   * @return   number             The index of the element found (or -1 for no match)
+   * @param int[] $haystack The array to search.
+   * @param mixed $needle The value to search for.
+   *
+   * @return int The index of the element found, or -1 for no match.
    *
    */
   private function index_of($haystack, $needle)

--- a/src/mnemonic.php
+++ b/src/mnemonic.php
@@ -30,14 +30,25 @@
 namespace MoneroIntegrations\MoneroPhp;
 
 /**
- * A standalone class to encode, decode, and validate monero mnemonics
- * All access to this class is via static methods, so it never needs to
- * be instantiated.
+ * A standalone class to encode, decode, and validate Monero mnemonics.
+ *
+ * This class provides static methods for encoding, decoding, and validating Monero mnemonics.
+ * It is designed to be used without instantiation as the methods are all static.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
  */
 class mnemonic {
 
     /**
-     * Given a mnemonic seed word list, return a string of the seed checksum.
+     * Calculate the checksum of a mnemonic seed word list.
+     *
+     * Given a mnemonic seed word list, this function calculates and returns
+     * a string representing the seed checksum.
+     *
+     * @param array $words The array of mnemonic seed words.
+     * @param int $prefix_len The length of the prefix used for each word.
+     * 
+     * @return string The seed checksum.
      */
     static function checksum($words, $prefix_len) {
         $plen = $prefix_len;
@@ -54,16 +65,29 @@ class mnemonic {
     }
     
     /**
-     * Given a mnemonic seed word list, check if checksum word is valid.
-     * Returns boolean value.
+     * Validate the checksum of a mnemonic seed word list.
+     *
+     * Given a mnemonic seed word list and a prefix length, this function checks
+     * if the checksum word is valid.
+     *
+     * @param array $words The array of mnemonic seed words.
+     * @param int $prefix_len The length of the prefix used for each word.
+     * 
+     * @return bool Returns true if the checksum is valid, otherwise false.
      */
     static function validate_checksum($words, $prefix_len) {
         return (self::checksum($words, $prefix_len) == $words[count($words)-1]) ? true : false;
     }
 
     /**
-     * Given an 8 byte word (or shorter),
-     * pads to 8 bytes (adds 0 at left) and reverses endian byte order.
+     * Swap endian byte order and pad a hexadecimal word.
+     *
+     * Given an 8-byte or shorter hexadecimal word, this function pads it to
+     * 8 bytes (adding leading zeros) and reverses the byte order.
+     *
+     * @param string $word The input hexadecimal word.
+     * 
+     * @return string The processed hexadecimal word.
      */
     static function swap_endian($word) {
         $word = str_pad ( $word, 8, 0, STR_PAD_LEFT);
@@ -71,12 +95,16 @@ class mnemonic {
     }
     
     /**
-     * Given a hexadecimal key string (seed),
-     * return it's mnemonic representation.
+     * Encode a hexadecimal key as a mnemonic representation.
      *
-     * @todo if anyone can make this work reliably with
-     * pure PHP math (no gmp or bcmath), please submit a
-     * pull request.
+     * Given a hexadecimal key (seed), this function encodes it into a mnemonic representation.
+     *
+     * @param string $seed The hexadecimal key to encode.
+     * @param string|null $wordset_name The name of the wordset to use.
+     * 
+     * @return array An array of mnemonic words.
+     * 
+     * @todo Consider supporting pure PHP math for gmp functions.
      */
     static function encode($seed, $wordset_name = null) {
         assert(mb_strlen($seed) % 8 == 0);
@@ -100,9 +128,15 @@ class mnemonic {
     }
 
     /**
-     * Given a hexadecimal key string (seed),
-     * return it's mnemonic representation plus an
-     * extra checksum word.
+     * Encode a hexadecimal key as a mnemonic representation with an extra checksum word.
+     *
+     * Given a hexadecimal key (seed), this function encodes it into a mnemonic representation
+     * and appends an extra checksum word.
+     *
+     * @param string $message The hexadecimal key to encode.
+     * @param string|null $wordset_name The name of the wordset to use.
+     * 
+     * @return array An array of mnemonic words including the checksum word.
      */
     static function encode_with_checksum($message, $wordset_name = null) {
         $list = self::encode($message, $wordset_name);
@@ -113,11 +147,17 @@ class mnemonic {
     }
     
     /**
-     * Given a mnemonic word list, return a hexadecimal encoded string (seed).
+     * Decode a mnemonic word list into a hexadecimal encoded string (seed).
      *
-     * @todo if anyone can make this work reliably with
-     * pure PHP math (no gmp or bcmath), please submit a
-     * pull request.
+     * Given a mnemonic word list and an optional wordset name, this function decodes
+     * the mnemonic and returns a hexadecimal encoded string (seed).
+     *
+     * @param array $wlist The array of mnemonic words.
+     * @param string|null $wordset_name The name of the wordset to use.
+     * 
+     * @return string The hexadecimal encoded seed.
+     * 
+     * @todo Consider supporting pure PHP math for gmp functions.
      */
     static function decode($wlist, $wordset_name = null) {
         $wordset = self::get_wordset_by_name( $wordset_name );
@@ -159,7 +199,13 @@ class mnemonic {
     }
     
     /**
-     * Given a wordset identifier, returns the full wordset
+     * Get the full wordset by its identifier.
+     *
+     * Given a wordset identifier, this function returns the full wordset array.
+     *
+     * @param string|null $name The name of the wordset.
+     * 
+     * @return array The wordset information.
      */
     static public function get_wordset_by_name($name = null) {
         $name = $name ?: 'english';
@@ -210,16 +256,23 @@ class mnemonic {
     
     
     /**
-     * returns list of available wordsets
+     * Get a list of available wordsets.
+     *
+     * This function returns an array containing the names of all available wordsets.
+     *
+     * @return array The list of available wordset names.
      */
     static public function get_wordset_list() {
         return array_keys( self::get_wordsets() );
     }
     
     /**
-     * This function returns all available wordsets.
+     * Get all available wordsets.
      *
-     * Each wordset is in a separate file in wordsets/*.ws.php
+     * This function returns an array containing information about all available wordsets.
+     * Each wordset includes name, English name, prefix length, and the list of words.
+     *
+     * @return array An array of available wordsets.
      */
     static public function get_wordsets() {
         
@@ -268,30 +321,41 @@ class mnemonic {
     
 }
 
-
+/**
+ * Interface wordset
+ *
+ * This interface defines methods to retrieve information about a wordset, which is used in mnemonic encoding and decoding.
+ */
 interface wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string;
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English. This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string;
     
-    /* Returns integer indicating length of unique prefix,
+    /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
+     * @return int
      */
     static public function prefix_length() : int;
     
-    /* Returns an array of all words in the wordset.
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
      */
     static public function words() : array;    
 };

--- a/src/subaddress.php
+++ b/src/subaddress.php
@@ -15,7 +15,7 @@
  *
  * This class provides methods for generating subaddresses and related keys.
  *
- * @package monerophp
+ * @package MoneroIntegrations\MoneroPhp\subaddress
  *
  */
 class subaddress

--- a/src/subaddress.php
+++ b/src/subaddress.php
@@ -1,29 +1,43 @@
 <?php 
+/**
+ *
+ * monerophp/subaddress
+ *
+ * PHP Monero subaddress implementation
+ * https://github.com/monero-integrations/monerophp
+ *
+ * @author Monero Integrations Team <support@monerointegrations.com> (https://github.com/monero-integrations)
+ *
+ */
 
-/*
-  Copyright (c) 2018-2019, Monero Integrations
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
+ /**
+ * PHP subaddress implementation
+ *
+ * This class provides methods for generating subaddresses and related keys.
+ *
+ * @package monerophp
+ *
+ */
 class subaddress
 {
+	/**
+     * @var ed25519 The ed25519 instance.
+     */
 	protected $ed25519;
+
+	/**
+     * @var base58 The base58 instance.
+     */
 	protected $base58;
+
+	/**
+     * @var bool Indicates if the GMP extension is loaded.
+     */
+	protected $gmp;
 	
+	/**
+     * Creates a new subaddress class instance.
+     */
 	public function __construct()
 	{
 		$this->ed25519 = new ed25519();
@@ -31,6 +45,14 @@ class subaddress
 		$this->gmp = extension_loaded('gmp');
 	}
 	
+	/**
+     * Reduce a scalar modulo of the ed25519 prime.
+     *
+     * @param string $input The hex-encoded scalar to be reduced.
+	 * 
+     * @return string Hex-encoded reduced scalar.
+	 * 
+     */
 	private function sc_reduce($input)
 	{
 		$integer = $this->ed25519->decodeint(hex2bin($input));
@@ -42,12 +64,30 @@ class subaddress
 		return $result;
 	}
 	
+	/**
+     * Add two points on the edwards25519 curve.
+     *
+     * @param string $point1 The first hex-encoded point.
+     * @param string $point2 The second hex-encoded point.
+	 * 
+     * @return string Hex-encoded result of the addition.
+	 * 
+	 */
 	private function ge_add($point1, $point2)
 	{
 		$point3 = $this->ed25519->edwards($this->ed25519->decodepoint(hex2bin($point1)), $this->ed25519->decodepoint(hex2bin($point2)));
 		return bin2hex($this->ed25519->encodepoint($point3));
 	}
 	
+	/**
+     * Perform scalar multiplication of a point.
+     *
+     * @param string $public The hex-encoded public point.
+     * @param string $secret The hex-encoded secret scalar.
+	 * 
+     * @return string Hex-encoded result of scalar multiplication.
+	 * 
+     */
 	private function ge_scalarmult($public, $secret)
 	{
 		$point = $this->ed25519->decodepoint(hex2bin($public));
@@ -56,6 +96,14 @@ class subaddress
 		return bin2hex($this->ed25519->encodepoint($res));
 	}
 	
+	/**
+     * Perform scalar multiplication of a base point.
+     *
+     * @param string $scalar The hex-encoded scalar.
+	 * 
+     * @return string Hex-encoded result of base point scalar multiplication.
+	 * 
+     */
 	private function ge_scalarmult_base($scalar)
 	{
 		$decoded = $this->ed25519->decodeint(hex2bin($scalar));
@@ -63,11 +111,14 @@ class subaddress
 		return bin2hex($this->ed25519->encodepoint($res));
 	}
 	
-	/*
-	 * @param string Hex encoded string of the data to hash
-	 * @return string Hex encoded string of the hashed data
-	 *
-	 */
+	/**
+     * Calculate the Keccak-256 hash of input data.
+     *
+     * @param string $message The hex-encoded data to hash.
+	 * 
+     * @return string Hex-encoded hash result.
+	 * 
+     */
 	private function keccak_256($message)
 	{
 		$keccak256 = SHA3::init(SHA3::KECCAK_256);
@@ -75,13 +126,14 @@ class subaddress
 		return bin2hex($keccak256->squeeze(32)) ;
 	}
 
-	/*
-	 * Hs in the cryptonote white paper
-	 *
-	 * @param string Hex encoded data to hash
-	 *
-	 * @return string A 32 byte encoded integer
-	 */
+	/**
+     * Calculate the hash-to-scalar result (in the CryptoNote whitepaper).
+     *
+     * @param string $data The hex-encoded data to hash.
+	 * 
+     * @return string Hex-encoded scalar result.
+	 * 
+     */
 	private function hash_to_scalar($data)
 	{
 		$hash = $this->keccak_256($data);
@@ -89,6 +141,16 @@ class subaddress
 		return $scalar;
 	}
 	
+	/**
+     * Generate the subaddress secret key.
+     *
+     * @param int $major_index Major index.
+     * @param int $minor_index Minor index.
+     * @param string $sec_key The hex-encoded secret key.
+	 * 
+     * @return string Hex-encoded subaddress secret key.
+	 * 
+     */
 	public function generate_subaddr_secret_key($major_index, $minor_index, $sec_key)
 	{
 		$prefix = "5375624164647200"; // hex encoding of string "SubAddr"
@@ -96,6 +158,15 @@ class subaddress
 		return $this->hash_to_scalar($prefix . $sec_key . bin2hex($index));
 	}
 	
+	/**
+     * Generate the subaddress spend public key.
+     *
+     * @param string $spend_public_key The hex-encoded spend public key.
+     * @param string $subaddr_secret_key The hex-encoded subaddress secret key.
+	 * 
+     * @return string Hex-encoded subaddress spend public key.
+	 * 
+     */
 	public function generate_subaddress_spend_public_key($spend_public_key, $subaddr_secret_key)
 	{
 		$mG = $this->ge_scalarmult_base($subaddr_secret_key);
@@ -103,11 +174,31 @@ class subaddress
 		return $D;
 	}
 	
+	/**
+     * Generate the subaddress view public key.
+     *
+     * @param string $subaddr_spend_public_key The hex-encoded subaddress spend public key.
+     * @param string $view_secret_key The hex-encoded view secret key.
+	 * 
+     * @return string Hex-encoded subaddress view public key.
+	 * 
+     */
 	public function generate_subaddr_view_public_key($subaddr_spend_public_key, $view_secret_key)
 	{
 		return $this->ge_scalarmult($subaddr_spend_public_key, $view_secret_key);
 	}
 	
+	/**
+     * Generate a subaddress.
+     *
+     * @param int $major_index Major index.
+     * @param int $minor_index Minor index.
+     * @param string $view_secret_key The hex-encoded view secret key.
+     * @param string $spend_public_key The hex-encoded spend public key.
+	 * 
+     * @return string Base58-encoded subaddress.
+	 * 
+     */
 	public function generate_subaddress($major_index, $minor_index, $view_secret_key, $spend_public_key)
 	{
 		$subaddr_secret_key = $this->generate_subaddr_secret_key($major_index, $minor_index, $view_secret_key);

--- a/src/wordsets/chinese_simplified.ws.php
+++ b/src/wordsets/chinese_simplified.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - Chinese (Simplified) Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Chinese (Simplified) wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Chinese (simplified) Wordset Class
+ *
+ * This class defines the Chinese (simplified) wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class chinese_simplified implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "简体中文 (中国)";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Chinese (simplified)";
     }
 
-    /* Returns integer indicating length of unique prefix,
+    /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 1;  // first letter of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */
     static public function words() : array {
         return [
             "的",

--- a/src/wordsets/dutch.ws.php
+++ b/src/wordsets/dutch.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - Dutch Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Dutch wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Dutch Wordset Class
+ *
+ * This class defines the Dutch wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class dutch implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Nederlands";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Dutch";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */   
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */   
     static public function words() : array {
         return [
             "aalglad",

--- a/src/wordsets/english.ws.php
+++ b/src/wordsets/english.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - English Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the English wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * English Wordset Class
+ *
+ * This class defines the English wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class english implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "English";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "English";        
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 3;  // first 3 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */ 
     static public function words() : array {
         return [
             "abbey",

--- a/src/wordsets/english_old.ws.php
+++ b/src/wordsets/english_old.ws.php
@@ -1,42 +1,66 @@
 <?php
-
+/**
+ * Monero PHP Library - English (old) Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the English (old) wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
 /*!
  * Older version of English word list and map.
  */
 
-
+/**
+ * English (old) Wordset Class
+ *
+ * This class defines the English (old) wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class english_old implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "EnglishOld";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "English (old)";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
+     * @return int
      */    
     static public function prefix_length() : int {
         return 0;  // require entire word.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */ 
     static public function words() : array {
         return [
             "like",

--- a/src/wordsets/esperanto.ws.php
+++ b/src/wordsets/esperanto.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - Esperanto Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Esperanto wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Esperanto Wordset Class
+ *
+ * This class defines the Esperanto wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class esperanto implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Esperanto";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Esperanto";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */  
     static public function words() : array {
         return [
             "abako",

--- a/src/wordsets/french.ws.php
+++ b/src/wordsets/french.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - French Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the French wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * French Wordset Class
+ *
+ * This class defines the French wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class french implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Français";        
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "French";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */ 
     static public function words() : array {
         return [
             "abandon",

--- a/src/wordsets/german.ws.php
+++ b/src/wordsets/german.ws.php
@@ -1,38 +1,63 @@
 <?php
-
+/**
+ * Monero PHP Library - German Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the German wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * German Wordset Class
+ *
+ * This class defines the German wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class german implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Deutsch"; 
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "German";
     }
 
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */ 
     static public function words() : array {
         return [
             "Abakus",

--- a/src/wordsets/italian.ws.php
+++ b/src/wordsets/italian.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - Italian Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Italian wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Italian Wordset Class
+ *
+ * This class defines the Italian wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class italian implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Italiano";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Italian";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */
     static public function words() : array {
         return [
             "abbinare",

--- a/src/wordsets/japanese.ws.php
+++ b/src/wordsets/japanese.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - Japanese Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Japanese wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Japanese Wordset Class
+ *
+ * This class defines the Japanese wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class japanese implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "日本語";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Japanese";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 3;  // first 3 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */
     static public function words() : array {
         return [
             "あいこくしん",

--- a/src/wordsets/lojban.ws.php
+++ b/src/wordsets/lojban.ws.php
@@ -1,37 +1,62 @@
 <?php
-
+/**
+ * Monero PHP Library - Lojban Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Lojban wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Lojban Wordset Class
+ *
+ * This class defines the Lojban wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class lojban implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Lojban";        
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Lojban";                
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */  
     static public function words() : array {
         return [
             "backi",

--- a/src/wordsets/portuguese.ws.php
+++ b/src/wordsets/portuguese.ws.php
@@ -1,38 +1,63 @@
 <?php
-
+/**
+ * Monero PHP Library - Portuguese Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Portuguese wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Portuguese Wordset Class
+ *
+ * This class defines the Portuguese wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class portuguese implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Português";
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Portuguese";
     }
 
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */ 
     static public function words() : array {
         return [
             "abaular",

--- a/src/wordsets/russian.ws.php
+++ b/src/wordsets/russian.ws.php
@@ -1,38 +1,63 @@
 <?php
-
+/**
+ * Monero PHP Library - Russian Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Russian wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Russian Wordset Class
+ *
+ * This class defines the Russian wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class russian implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "русский язык";
         
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Russian";
     }
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 3;  // first 3 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */ 
     static public function words() : array {
         return [
             "абажур",

--- a/src/wordsets/spanish.ws.php
+++ b/src/wordsets/spanish.ws.php
@@ -1,39 +1,64 @@
 <?php
-
+/**
+ * Monero PHP Library - Spanish Wordset for Mnemonic Generation
+ *
+ * This file contains the implementation of the Spanish wordset
+ * for generating mnemonics in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 namespace MoneroIntegrations\MoneroPhp\mnemonic;
 
+/**
+ * Spanish Wordset Class
+ *
+ * This class defines the Spanish wordset for generating mnemonics
+ * in the Monero PHP library.
+ *
+ * @package MoneroIntegrations\MoneroPhp\mnemonic
+ */
 class spanish implements wordset {
-
-    /* Returns name of wordset in the wordset's native language.
+    /**
+     * Returns name of wordset in the wordset's native language.
+     * 
      * This is a human-readable string, and should be capitalized
      * if the language supports it.
+     * 
+     * @return string
      */
     static public function name() : string {
         return "Español";
         
     }
 
-    /* Returns name of wordset in english.    
-     * This is a human-readable string, and should be capitalized
+    /**
+     * Returns name of wordset in English.
+     * 
+     * This is a human-readable string, and should be capitalized.
+     * 
+     * @return string
      */
     static public function english_name() : string {
         return "Spanish";
     }
 
 
-    /* Returns integer indicating length of unique prefix,
+     /**
+     * Returns integer indicating length of unique prefix,
      * such that each prefix of this length is unique across
      * the entire set of words.
      *
-     * A value of 0 indicates that there is no unique prefix
-     * and the entire word must be used instead.
-     */    
+     * @return int
+     */
     static public function prefix_length() : int {
         return 4;  // first 4 letters of each word in wordset is unique.
     }
     
-    /* Returns an array of all words in the wordset.
-     */    
+    /**
+     * Returns the array of all words in the wordset.
+     *
+     * @return array
+     */
     static public function words() : array {
         return [
             "ábaco",


### PR DESCRIPTION
Documentation is very inconsistent, and PHPDoc is very simple to use and generates nice-looking documentation.

Progress:
- [x] wordsets
- [x] base58
- [ ] Cryptonote
- [ ] daemonRPC
- [ ] ed25519
- [ ] jsonRPCClient (after #138 merge)
- [x] mnemonic
- ~~Serialize~~
- ~~SHA3~~
- [x] subaddress
- [x] Varint
- [ ] walletRPC