### PR TITLE
Add full path to `phpcbf` in pre-commit hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "extra": {
         "hooks": {
             "pre-commit": [
-                "phpcbf"
+                "vendor/bin/phpcbf"
             ]
         }
     },


### PR DESCRIPTION
The GitHub Action failed because it could not find `phpcbf`.

I think this is going to cause a problem for others when they try to commit on their machines. I have `:./vendor/bin` in my `$PATH` to allow just running Composer installed bin/executable files from the project root.