### PR TITLE
Fix dynamic property deprecation warnings

### DIFF
--- a/src/Cryptonote.php
+++ b/src/Cryptonote.php
@@ -30,6 +30,9 @@ use kornrunner\Keccak as keccak;
     class Cryptonote
     {
         protected $ed25519;
+        protected $base58;
+        protected $varint;
+
         public function __construct()
         {
             $this->ed25519 = new ed25519();

--- a/src/daemonRPC.php
+++ b/src/daemonRPC.php
@@ -43,6 +43,7 @@ class daemonRPC
   private $url;
   private $user;
   private $password;
+  private $check_SSL;
 
   /**
    *

--- a/src/jsonRPCClient.php
+++ b/src/jsonRPCClient.php
@@ -18,6 +18,7 @@ class jsonRPCClient
     protected $url = null, $is_debug = false, $parameters_structure = 'array';
     private $username;
     private $password;
+    private $SSL;
     protected $curl_options = array(
         CURLOPT_CONNECTTIMEOUT => 8,
         CURLOPT_TIMEOUT => 8

--- a/src/subaddress.php
+++ b/src/subaddress.php
@@ -29,7 +29,8 @@ class subaddress
 {
 	protected $ed25519;
 	protected $base58;
-	
+	protected $gmp;
+
 	public function __construct()
 	{
 		$this->ed25519 = new ed25519();

--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -43,6 +43,7 @@ class walletRPC
   private $url;
   private $user;
   private $password;
+  private $check_SSL;
 
   /**
    *


### PR DESCRIPTION
Fixes [deprecation warnings around dynamic properties](https://php.watch/versions/8.2/dynamic-properties-deprecated) shown when running this library under PHP 8.2.

Essentially, this is deprecated:

```php
class User {
    public function __construct() {
        $this->name = 'test';
    }
}
```

where `name` must be declared as a class property:

```php
class User {
    private $name;
    public function __construct() {
        $this->name = 'test';
    }
}
```