### PR TITLE
Remove extraneous require statements

### DIFF
--- a/src/Cryptonote.php
+++ b/src/Cryptonote.php
@@ -22,8 +22,6 @@
 */
 namespace MoneroIntegrations\MoneroPhp;
 
-require 'vendor/autoload.php';
-
 use kornrunner\Keccak as keccak;
     use Exception;
 

--- a/src/subaddress.php
+++ b/src/subaddress.php
@@ -21,8 +21,6 @@
 
 namespace MoneroIntegrations\MoneroPhp;
 
-require 'vendor/autoload.php';
-
 use kornrunner\Keccak as keccak;
 
 class subaddress


### PR DESCRIPTION
Removes two `require('vendor/autoload.php');` statements from the source code, as it should be up to the user of this library to handle setting up the composer autoload, not the library itself. Having these requires breaks trying to use this library for people who's working directory is not the root of their project where composer installs the dependencies, and then doing `require('vendor/autoload.php')` will not work due to the nature of relative pathing.

These statements were introduced in #141 though I am not sure why, and they were only introduced to two classes vs everywhere within the library.