### PR TITLE
Fix verifying checksum for integrated addresses

### DIFF
--- a/src/Cryptonote.php
+++ b/src/Cryptonote.php
@@ -239,13 +239,9 @@ use kornrunner\Keccak as keccak;
     {
         $decoded = $this->base58->decode($address);
         $checksum = substr($decoded, -8);
-        $checksum_hash = $this->keccak_256(substr($decoded, 0, 130));
+        $checksum_hash = $this->keccak_256(substr($decoded, 0, -8));
         $calculated = substr($checksum_hash, 0, 8);
-        if($checksum == $calculated){
-            return true;
-        }
-        else
-        return false;
+        return $checksum === $calculated;
     }
 
     /*


### PR DESCRIPTION
Fix a bug in the `Cryptonote::verify_checksum` function where it would fail on [integrated addresses](https://www.getmonero.org/resources/moneropedia/address.html#integrated-address) where these addresses are 154 characters when decoded (106 encoded), where the checksum is the last 8 characters, similar to regular addresses which decode to 138 characters.

By using a negative offset for `substr`, this will grab the last 8 characters, regardless of length of `$decoded`, which helps future proof this in the case a new address type is ever introduced.

As a testcase, the [monerodocs on integrated addresses](https://web.archive.org/web/20230902093956/https://monerodocs.org/public-address/integrated-address/) provides a sample address:

```
4LL9oSLmtpccfufTMvppY6JwXNouMBzSkbLYfpAV5Usx3skxNgYeYTRj5UzqtReoS44qo9mtmXCqY45DJ852K5Jv2bYXZKKQePHES9khPK
```

where on `master`:
```
php > $c = new MoneroIntegrations\MoneroPhp\Cryptonote();
php > var_dump($c->verify_checksum('4LL9oSLmtpccfufTMvppY6JwXNouMBzSkbLYfpAV5Usx3skxNgYeYTRj5UzqtReoS44qo9mtmXCqY45DJ852K5Jv2bYXZKKQePHES9khPK'));
bool(false)
```

and with this patch:
```
php > $c = new MoneroIntegrations\MoneroPhp\Cryptonote();
php > $c->verify_checksum('4LL9oSLmtpccfufTMvppY6JwXNouMBzSkbLYfpAV5Usx3skxNgYeYTRj5UzqtReoS44qo9mtmXCqY45DJ852K5Jv2bYXZKKQePHES9khPK');
php > var_dump($c->verify_checksum('4LL9oSLmtpccfufTMvppY6JwXNouMBzSkbLYfpAV5Usx3skxNgYeYTRj5UzqtReoS44qo9mtmXCqY45DJ852K5Jv2bYXZKKQePHES9khPK'));
bool(true)
```

The regular address provided in #135 returns `true` for both `master` and this branch.