### PR TITLE
Set CURLOPT_HTTP09_ALLOWED to true

### DIFF
--- a/src/jsonRPCClient.php
+++ b/src/jsonRPCClient.php
@@ -115,6 +115,7 @@ class jsonRPCClient
         curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip,deflate');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_HTTP09_ALLOWED, 1);
 
         if ($this->SSL)
         {


### PR DESCRIPTION
CURL allowed HTTP/0.9 responses by default before 7.66.0, but since 7.66.0, libcurl requires this option set to 1L to allow HTTP/0.9 responses. This is required for interacting with Monero wallet as it uses HTTP/0.9.

https://curl.se/libcurl/c/CURLOPT_HTTP09_ALLOWED.html